### PR TITLE
Remove check for .ql-editor

### DIFF
--- a/app/assets/javascripts/quill.global.js
+++ b/app/assets/javascripts/quill.global.js
@@ -94,9 +94,7 @@
     };
 
     $( document ).on('ready page:change turbolinks:load', function() {
-        if ($('.ql-editor').length <= 0){
-            Quilljs.loadDefaults();
-        }
+      Quilljs.loadDefaults();
     });
 
 //Debounce function exported from underscore.js to sync the quill container with the hidden input field


### PR DESCRIPTION
Remove check for .ql-editor so it can be used for styling without affecting quill initialization